### PR TITLE
`mount` config changed in Snowpack v2.15.0

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -12,7 +12,7 @@ module.exports = function plugin(snowpackConfig, options) {
         let relativePath;
         for (const [dirDisk, dirUrl] of Object.entries(snowpackConfig.mount)) {
           if (id.startsWith(dirDisk)) {
-            relativePath = path.dirname(id.replace(dirDisk, dirUrl));
+            relativePath = path.dirname(id.replace(dirDisk, dirUrl.url));
           }
         }
 


### PR DESCRIPTION
https://www.snowpack.dev/#config.mount

**\*New in Snowpack `v2.15.0`:** You can customize the build behavior for a mounted directory using the expanded object notation:

- `url` _required_: The URL to mount to, matching the simple form above.
- `static` _optional, default: false_: If true, don't build files in this directory and serve them directly to the browser.
- `resolve` _optional, default: true_: If false, don't resolve JS & CSS imports in your JS, CSS, and HTML files and send every import to the browser, as written. We recommend that you don't disable this unless absolutely necessary, since it prevents Snowpack from handling your imports to things like packages, JSON files, CSS modules, and more.