### PR TITLE
Fix breaking URLs on windows

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -12,7 +12,7 @@ module.exports = function plugin(snowpackConfig, options) {
         let relativePath;
         for (const [dirDisk, dirUrl] of Object.entries(snowpackConfig.mount)) {
           if (id.startsWith(dirDisk)) {
-            relativePath = path.dirname(id.replace(dirDisk, dirUrl.url));
+            relativePath = path.dirname(id.replace(dirDisk, dirUrl.url)).split(path.sep).join(path.posix.sep);
           }
         }
 
@@ -26,7 +26,7 @@ module.exports = function plugin(snowpackConfig, options) {
               // don't touch absolute URLs
               return url;
             } else {
-              return path.join(relativePath, url);
+              return path.join(relativePath, url).split(path.sep).join(path.posix.sep);
             }
           });
           return newContents;


### PR DESCRIPTION
Paths created by this plugin contain backslashes on Windows systems. This breaks the URLs in the browser. This PR makes sure that paths only use posix (/) separators.